### PR TITLE
Support object with properties having dots in their names

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Library for generating and applying protobuf [FieldMask](https://developers.goog
 function generateFieldMask(object)
 ```
 
+The name of the properties containing `.` or `\` characters are escaped. 
+
 For an example, running this function with this input:
 ```
 {
@@ -26,14 +28,16 @@ For an example, running this function with this input:
     a: 22,
     b: {
       d: 1
-    }
+    },
+    'b.d': 33,
+    'x\\y': 44
   }
 }
 ```
 
 generates this output:
 ```
-['f.a', 'f.b.d']
+['f.a', 'f.b.d', 'f.b\\.d', "f.x\\\\y"]
 ```
 
 ### applyFieldMask
@@ -47,6 +51,8 @@ generates this output:
 function applyFieldMask(sourceObject, fieldMask)
 ```
 
+Respects the escaping of the property names in the `fieldMask`.
+
 For an example, running this function with this input:
 ```
 {
@@ -56,11 +62,12 @@ For an example, running this function with this input:
       d: 1,
       x: 2
     },
+    'b.d': 33,
     y: 13
   },
   z: 8
 },
-['f.a', 'f.b.d']
+['f.a', 'f.b.d', 'f.b\\.d']
 ```
 
 generates this output:
@@ -70,7 +77,8 @@ generates this output:
     a: 22,
     b: {
       d: 1
-    }
+    },
+    'b.d': 33
   }
 }
 ```

--- a/lib/escaping.js
+++ b/lib/escaping.js
@@ -2,8 +2,9 @@ function escape(propertyName) {
   return propertyName.replace(/\\/g, '\\\\').replace(/\./g, '\\.');
 }
 
-function unescapeAndSplit(path) {
+function unescapeAndSplit(originalPath) {
   const properties = [];
+  let path = originalPath;
   let i = path.indexOf('.');
   while (i >= 0) {
     if (isEscapedDot(path, i)) {

--- a/lib/escaping.js
+++ b/lib/escaping.js
@@ -1,0 +1,43 @@
+function escape(propertyName) {
+  return propertyName.replace(/\\/g, '\\\\').replace(/\./g, '\\.');
+}
+
+function unescapeAndSplit(path) {
+  const properties = [];
+  let i = path.indexOf('.');
+  while (i >= 0) {
+    if (isEscapedDot(path, i)) {
+      path = unescapeFirstDotChar(path);
+      // Find the index of the first dot AFTER the one we just unescaped
+      i = path.indexOf('.', i);
+    } else {
+      const firstProperty = path.substring(0, i);
+      properties.push(unescapeEscapeChars(firstProperty));
+      path = path.substring(i + 1);
+      i = path.indexOf('.');
+    }
+  }
+
+  properties.push(unescapeEscapeChars(path));
+  return properties;
+}
+
+function unescapeFirstDotChar(str) {
+  return str.replace('\\.', '.');
+}
+
+function unescapeEscapeChars(str) {
+  return str.replace(/\\\\/g, '\\');
+}
+
+function isEscapedDot(path, i) {
+  let counter = 0;
+  while (path.substring(i - 1, i) === '\\') {
+    counter++;
+    i--;
+  }
+
+  return counter % 2 === 1;
+}
+
+module.exports = { escape, unescapeAndSplit };

--- a/lib/fieldmask.js
+++ b/lib/fieldmask.js
@@ -1,5 +1,6 @@
 const get = require('lodash.get');
 const set = require('lodash.set');
+const { escape, unescapeAndSplit } = require('./escaping');
 
 /**
  * Creates a new object that copies fields present in field mask from specified source object
@@ -14,7 +15,7 @@ function applyFieldMask(sourceObject, fieldMask) {
   const result = {};
 
   for (let i = 0; i < fieldMask.length; i++) {
-    const path = fieldMask[i];
+    const path = unescapeAndSplit(fieldMask[i]);
     const sourceValue = get(sourceObject, path);
     set(result, path, sourceValue);
   }
@@ -42,7 +43,7 @@ function _generatePathForObject(object, path, paths) {
   for (let property in object) {
     if (object.hasOwnProperty(property)) {
       let expandedPath = path.length > 0 ? path + '.' : path;
-      expandedPath += property;
+      expandedPath += escape(property);
 
       const objProperty = object[property];
       if (_isObject(objProperty) && !Array.isArray(objProperty)) {

--- a/test/escaping.spec.js
+++ b/test/escaping.spec.js
@@ -1,0 +1,60 @@
+const { assert } = require('chai');
+const { escape, unescapeAndSplit } = require('../lib/escaping');
+
+describe('Escaping', () => {
+  describe('escape', () => {
+    it('should return property name as is when it does not contain special characters', () => {
+      assert.equal(escape('foo'), 'foo');
+    });
+
+    it('should escape dots in the property name', () => {
+      assert.equal(escape('foo.bar'), 'foo\\.bar');
+    });
+
+    it('should escape multiple dots in the property name', () => {
+      assert.equal(escape('foo.bar.baz.'), 'foo\\.bar\\.baz\\.');
+    });
+
+    it('should escape the escape char', () => {
+      assert.equal(escape('foo\\bar'), 'foo\\\\bar');
+    });
+
+    it('should escape the escape char when containing with dots', () => {
+      assert.equal(escape('foo\\.bar'), 'foo\\\\\\.bar');
+    });
+  });
+
+  describe('unescapeAndSplit', () => {
+    it('should array with single element when path is for a single property', () => {
+      assert.deepEqual(unescapeAndSplit('foo'), ['foo']);
+    });
+
+    it('should return an array of names split by dot', () => {
+      assert.deepEqual(unescapeAndSplit('foo.bar.baz'), ['foo', 'bar', 'baz']);
+    });
+
+    it('should unescape escaped dots', () => {
+      assert.deepEqual(unescapeAndSplit('foo\\.bar'), ['foo.bar']);
+    });
+
+    it('should return an array of names split by dot with respect to escaped dots', () => {
+      assert.deepEqual(unescapeAndSplit('foo\\.bar\\.baz.baf'), ['foo.bar.baz', 'baf']);
+    });
+
+    it('should handle trailing escaped dot correctly', () => {
+      assert.deepEqual(unescapeAndSplit('foo\\..baz'), ['foo.', 'baz']);
+    });
+
+    it('should handle escape char correctly', () => {
+      assert.deepEqual(unescapeAndSplit('foo\\\\.baz'), ['foo\\', 'baz']);
+    });
+
+    it('should handle escape char with dot correctly', () => {
+      assert.deepEqual(unescapeAndSplit('foo\\\\\\..baz'), ['foo\\.', 'baz']);
+    });
+
+    it('should play well with escape function results', () => {
+      assert.deepEqual(unescapeAndSplit(escape('foo\\.bar')), ['foo\\.bar']);
+    });
+  });
+});

--- a/test/fieldmask.spec.js
+++ b/test/fieldmask.spec.js
@@ -131,6 +131,54 @@ describe('fieldmask', () => {
 
     assert.deepEqual(result, 1);
   });
+
+  it('escaped property name', () => {
+    const result = fieldmask.applyFieldMask(
+      {
+        f: {
+          a: 22,
+          'b.z': {
+            d: 1,
+            x: 2
+          },
+          'b.': {
+            d: 1,
+            x: 2
+          },
+          'b\\b1': {
+            d: 1,
+            x: 2
+          },
+          b: {
+            z: {
+              d: 1,
+              x: 2
+            }
+          }
+        }
+      },
+      ['f.b\\.z.d', 'f.b.z.x', 'f.b\\..x', 'f.b\\\\b1.d']
+    );
+
+    assert.deepEqual(result, {
+      f: {
+        'b.z': {
+          d: 1
+        },
+        'b.': {
+          x: 2
+        },
+        'b\\b1': {
+          d: 1
+        },
+        b: {
+          z: {
+            x: 2
+          }
+        }
+      }
+    });
+  });
 });
 
 describe('generateFieldMask', () => {
@@ -215,5 +263,24 @@ describe('generateFieldMask', () => {
   it('undefined', () => {
     const mask = fieldmask.generateFieldMask();
     assert.deepEqual(mask, []);
+  });
+
+  it('escaping dots and escape chars in the property name', () => {
+    const mask = fieldmask.generateFieldMask({
+      f: {
+        'b.z': {
+          d: 1
+        },
+        b: {
+          z: {
+            d: 1
+          }
+        },
+        'b\\': {
+          x: 1
+        }
+      }
+    });
+    assert.deepEqual(mask, ['f.b\\.z.d', 'f.b.z.d', 'f.b\\\\.x']);
   });
 });


### PR DESCRIPTION
Resolves https://github.com/kibertoad/protobuf-fieldmask/issues/1

# In this PR
### generateFieldMask
- `generateFieldMask` function escapes `.` and `\` characters in the names of the properties. Example: 
   For this object
   ```
   {
     f: {
       b: {
         d: 1
       },
       'b.d': 33,
       'b\\d': 44
     }
   }
   ```
   it will generate `["f.b.d","f.b\\.d","f.b\\\\d"]`
   
### applyFieldMask
- `applyFieldMask` respects the `.` and `\` escaping. Example:
   For this call
   ```
    applyFieldMask(
      {
        f: {
          b: {
            z: {
              d: 1,
              x: 2
            }
          },
          'b.z': {
            d: 3,
            x: 4
          },
          'b\\z': {
            d: 5,
            x: 6
          },
        }
      }, 
      ['f.b.z.d', 'f.b\\.z.d', 'f.b\\z.d']
    );
   ```

   it will return this object
   ```
   {
     "f": {
       "b": {
         "z": {
           "d": 1
         }
       }
       "b.z": {
         "d": 3
       }
       "b\\z": {
         "d": 5
       }
     }
   }
   ```

## Note
This change could be breaking for those having `\` in the property names. So the major version update might be needed.