### PR TITLE
feat: generateFieldMask add support for js date

### DIFF
--- a/lib/fieldmask.js
+++ b/lib/fieldmask.js
@@ -46,6 +46,11 @@ function _generatePathForObject(object, path, paths) {
       expandedPath += escape(property);
 
       const objProperty = object[property];
+
+      if (_isDate(object[property])) {
+        paths.push(expandedPath);
+      }
+
       if (_isObject(objProperty) && !Array.isArray(objProperty)) {
         _generatePathForObject(objProperty, expandedPath, paths);
       } else if (!_isFunction(objProperty)) {
@@ -53,6 +58,10 @@ function _generatePathForObject(object, path, paths) {
       }
     }
   }
+}
+
+function _isDate(object) {
+  return object instanceof Date && !isNaN(object);
 }
 
 function _isObject(object) {

--- a/test/fieldmask.spec.js
+++ b/test/fieldmask.spec.js
@@ -102,6 +102,33 @@ describe('fieldmask', () => {
     });
   });
 
+  it('date property', () => {
+    const result = fieldmask.applyFieldMask(
+      {
+        a: new Date(1549312452000),
+        f: {
+          a: ['a', 'b'],
+          b: {
+            d: 1,
+            x: new Date(1549312452000),
+          },
+        },
+      },
+      ['a', 'f.a', 'f.b.d', 'f.b.x']
+    );
+
+    assert.deepEqual(result, {
+      a: new Date(1549312452000),
+      f: {
+        a: ['a', 'b'],
+        b: {
+          d: 1,
+          x: new Date(1549312452000),
+        },
+      },
+    });
+  });
+
   it('empty object', () => {
     const result = fieldmask.applyFieldMask({}, ['f.a', 'f.b.d']);
 
@@ -224,6 +251,19 @@ describe('generateFieldMask', () => {
 
     const mask = fieldmask.generateFieldMask(instance);
     assert.deepEqual(mask, ['fields.f.a', 'fields.f.b.d']);
+  });
+
+  it('date', () => {
+    const mask = fieldmask.generateFieldMask({
+      d: new Date(),
+      f: {
+        a: ['a', 'b'],
+        b: {
+          x: new Date(),
+        },
+      },
+    });
+    assert.deepEqual(mask, ['d', 'f.a', 'f.b.x']);
   });
 
   it('array', () => {


### PR DESCRIPTION
# Issue:
Js date is not supported and missing from the generated fieldmask

# PR:
Add support to js date, so the date is included in the generated fieldmask

```js
{
  d: new Date(),
  f: {
    a: ['a', 'b'],
    b: {
      x: new Date(),
    },
  },
}
```

return
```js
['d', 'f.a', 'f.b.x']
```
