### PR TITLE
Use `lodash` directly to fix security vulnerability

### DIFF
--- a/lib/fieldmask.js
+++ b/lib/fieldmask.js
@@ -1,5 +1,5 @@
-const get = require('lodash.get');
-const set = require('lodash.set');
+const get = require('lodash/get');
+const set = require('lodash/set');
 const { escape, unescapeAndSplit } = require('./escaping');
 
 /**

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   ],
   "homepage": "http://github.com/kibertoad/protobuf-fieldmask",
   "dependencies": {
-    "lodash.get": "^4.4.2",
-    "lodash.set": "^4.3.2"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "chai": "^4.3.4",


### PR DESCRIPTION
Per method packages have been deprecated and they are no longer updated. See https://lodash.com/per-method-packages.

I have been getting security reports due to these packages no longer being updated:

```
lodash.set  *
Severity: high
Prototype Pollution in lodash - https://github.com/advisories/GHSA-p6mc-m468-83gw
No fix available
node_modules/lodash.set
  protobuf-fieldmask  *
  Depends on vulnerable versions of lodash.set
  node_modules/protobuf-fieldmask
```

The issue however has been patched in `lodash` directly.